### PR TITLE
fix: typo in url

### DIFF
--- a/src/components/ReportButton.js
+++ b/src/components/ReportButton.js
@@ -36,7 +36,7 @@ function ReportButton({ reportResult,croppedImages }) {
     
     let probability = Math.round(reportResult.probability * 100);
     let percentage = `%7Cpercentage%3D${probability}`;
-    let url = `https://${prefix}.artsobservasjoner.no/SubmitSighting/SubmitSighting/`;
+    let url = `https://${prefix}.artsobservasjoner.no/SubmitSighting/`;
     let from = 'meta=from%3Dorakel%7C';
     let platform = `platform%3Ddesktopweb`;
     let reporttype = `Report?`;
@@ -62,6 +62,7 @@ function ReportButton({ reportResult,croppedImages }) {
   } else if (reportResult.taxon.scientificNameID) {
     reporttype = `ReportByScientificName/${reportResult.taxon.scientificNameID}?`;
   }           
+  console.log(url)
   return url+reporttype+from+platform+percentage;
   }
 


### PR DESCRIPTION
Den videresendte til feil artsobsurl for storskjerm og fikk derav en 404. Meget rask fiks. 
Nå er forresten alt på artsobsmobil ute i drift, så da kan orakelets videresending også settes ut i drift :) 